### PR TITLE
fix build macos

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: set OpenSSL environment variable
-      uses: allenevans/set-env@v1.0.0
+      uses: allenevans/set-env@v2.0.0
       with:
         OPENSSL_ROOT_DIR: '/usr/local/opt/openssl'
     - name: CMake set-up
@@ -25,4 +25,4 @@ jobs:
       with:
         name: srt_to_udp_server
         path: ./srt_to_udp_server
-    
+


### PR DESCRIPTION
Here is the fix for MacOS build.
In case you want to build de CentOS version with the slow bad version in docker you can check it [here](https://github.com/ghostnumber7/srt_to_udp_server/tree/fix/centos)